### PR TITLE
Update SimpleTable.js for Compatibility with Web AppBuilder 2.7

### DIFF
--- a/SimpleTable.js
+++ b/SimpleTable.js
@@ -602,7 +602,7 @@ define(['dojo/_base/declare',
                         })));
                     } else if (item === 'load') {
                         var loadDiv = html.create('div', {
-                            'class': 'action-item jimu-float-leading row-load-div jimu-icon jimu-icon-load'
+                            'class': 'action-item jimu-float-leading row-load-div jimu-icon jimu-icon-add'
                         }, actionItemParent);
                         loadDiv.title = "Load Map";
                         this.own(on(loadDiv, 'click', lang.hitch(this, function (event) {


### PR DESCRIPTION
When upgrading to Web AppBuilder 2.7, there are changes to Sprite files in ...\client\stemapp\jimu.js\css, particularly with sprite.css and sprite.png.  All references to jimu-icon-load appear to have been removed from Web AppBuilder 2.7.  A similar icon can be used by referencing jimu-icon-add.  This has been updated in SimpleTable.js on line 605.