### PR TITLE
SaveSession Widget for Web AppBuilder 2.7

### DIFF
--- a/SimpleTable.js
+++ b/SimpleTable.js
@@ -602,7 +602,7 @@ define(['dojo/_base/declare',
                         })));
                     } else if (item === 'load') {
                         var loadDiv = html.create('div', {
-                            'class': 'action-item jimu-float-leading row-load-div jimu-icon jimu-icon-load'
+                            'class': 'action-item jimu-float-leading row-load-div jimu-icon jimu-icon-add'
                         }, actionItemParent);
                         loadDiv.title = "Load Map";
                         this.own(on(loadDiv, 'click', lang.hitch(this, function (event) {

--- a/css/style.css
+++ b/css/style.css
@@ -11,26 +11,26 @@ div.jimu-widget-savesession .jimu-icon {
     margin-right: 5px;
 }
 
-.jimu-icon-load {
-    background-position: -0px -47px;
+.jimu-icon-add {
+    background-position: -0px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load.jimu-state-disabled {
-    background-position: -63px -47px;
+.jimu-icon-add.jimu-state-disabled {
+    background-position: -63px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load.jimu-state-hover {
-    background-position: -21px -47px;
+.jimu-icon-add.jimu-state-hover {
+    background-position: -21px -60px;
     width: 16px;
     height: 16px;
 }
 
-.jimu-icon-load:hover {
-    background-position: -21px -47px;
+.jimu-icon-add:hover {
+    background-position: -21px -60px;
     width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
ESRI has made updates to the sprite files in Web AppBuilder 2.7 at ...\client\stemapp\jimu.js\css.  This affects sprite.css and sprite.png. All references to jimu-icon-load appear to have been removed from Web AppBuilder 2.7.  A similar icon can be used by referencing jimu-icon-add.

When upgrading to Web AppBuilder 2.7, the Load Map icon in the SaveSession Widget was no longer present.  This has been fixed by updating line 605 of SaveSession\SimpleTable.js and updating references to jimu-icon-load in SaveSession\css\style.css.